### PR TITLE
Remove concat::setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,4 @@
 class sysfs {
-  include concat::setup
-
   package { 'sysfsutils':
     ensure => installed,
   }


### PR DESCRIPTION
This makes it compatible with recent versions of the concat module.
