### PR TITLE
Rely on sysfsutils refresh to apply settings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,16 +3,16 @@ class sysfs {
     ensure => installed,
   }
 
-  service { 'sysfsutils':
-    hasstatus  => false,
-    hasrestart => true,
-    subscribe  => Concat['/etc/sysfs.conf'],
-  }
-
   concat { '/etc/sysfs.conf':
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     require => Package['sysfsutils'],
+  } ~>
+  service { 'sysfsutils':
+    hasstatus  => false,
+    hasrestart => true,
+    enable     => true,
+    subscribe  => Concat['/etc/sysfs.conf'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,5 @@ class sysfs {
     hasstatus  => false,
     hasrestart => true,
     enable     => true,
-    subscribe  => Concat['/etc/sysfs.conf'],
   }
 }

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -4,11 +4,5 @@ define sysfs::setting($value) {
   concat::fragment { $name:
     target  => '/etc/sysfs.conf',
     content => "${name}=${value}\n",
-    notify  => Exec["Set /sys/${name} to ${value}"],
-  }
-
-  exec { "Set /sys/${name} to ${value}":
-    command     => "/bin/echo '${value}' > /sys/${name}",
-    refreshonly => true,
   }
 }


### PR DESCRIPTION
This change should allow us to rely on sysfsutils to change sysfs settings. The `sysfsutils` service will get refreshed when any of the settings change and change the values in `/sys` so changing the settings with `echo` is duplicative. Also adds an `enable => true` so settings get applied on boot.

/cc @dalen @kpaulisse @tomkrouper 